### PR TITLE
add version flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -11,7 +12,16 @@ import (
 	"github.com/cloudbase/garm/runner/providers/external/execution"
 )
 
+var version = flag.Bool("version", false, "prints version")
+var Version string
+
 func main() {
+	flag.Parse()
+	if *version {
+		fmt.Println(Version)
+		return
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), signals...)
 	defer stop()
 

--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -11,6 +11,10 @@ USER_ID=${USER_ID:-$UID}
 USER_GROUP=${USER_GROUP:-$(id -g)}
 
 cd $GARM_SOURCE
-go build -mod vendor -o $BIN_DIR/garm-provider-openstack -tags osusergo,netgo -ldflags "-linkmode external -extldflags '-static' -s -w" .
+go build -mod vendor -o $BIN_DIR/garm-provider-openstack \
+	-tags osusergo,netgo \
+	-ldflags "-linkmode external -extldflags '-static' -s -w" \
+	-ldflags "-X main.Version=$(git describe --always --dirty)" \
+	.
 
 chown $USER_ID:$USER_GROUP -R "$BIN_DIR"


### PR DESCRIPTION
Add a version flag that can be 'binary-stamped' at build-time, similar to garm.

<sub>Michael Kuhnt <michael.kuhnt@mercedes-benz.com> Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))
</sub>