### PR TITLE
fix: only list ACTIVE images

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -357,6 +357,7 @@ func (o *OpenstackClient) GetImage(nameOrID, imageVisibility string) (*images.Im
 	opts := images.ListOpts{
 		Name:       nameOrID,
 		Visibility: images.ImageVisibility(imageVisibility),
+		Status:     images.ImageStatusActive,
 	}
 	// perhaps it's a name. List all images and look for the image by name.
 	if err := images.List(o.image, opts).EachPage(func(page pagination.Page) (bool, error) {


### PR DESCRIPTION
It's not possible to start an instance from a non-active image.